### PR TITLE
Apt mirror fix

### DIFF
--- a/bashellite.sh
+++ b/bashellite.sh
@@ -427,6 +427,8 @@ Ensure_sync_provider_installed() {
       rm -fr ${script_dir}/_bin/${repo_name}/ &>/dev/null;
       mkdir -p ${script_dir}/_bin/${repo_name}/;
       git clone https://github.com/apt-mirror/apt-mirror.git ${script_dir}/_bin/${repo_name};
+      mkdir ${script_dir}/_bin/${repo_name}/var
+      ln -s ${script_dir}/_bin/${repo_name}/postmirror.sh ${script_dir}/_bin/${repo_name}/var/postmirror.sh
       chmod u+x ${script_dir}/_bin/${repo_name}/apt-mirror;
     fi
     sed -i "s%^\$config_file = .*%\$config_file = \"${script_dir}/_metadata/${repo_name}/aptmirror_url.conf\";%" ${script_dir}/_bin/${repo_name}/apt-mirror;

--- a/bashellite.sh
+++ b/bashellite.sh
@@ -430,6 +430,7 @@ Ensure_sync_provider_installed() {
       mkdir ${script_dir}/_bin/${repo_name}/var
       ln -s ${script_dir}/_bin/${repo_name}/postmirror.sh ${script_dir}/_bin/${repo_name}/var/postmirror.sh
       chmod u+x ${script_dir}/_bin/${repo_name}/apt-mirror;
+      chmod u+x ${script_dir}/_bin/${repo_name}/var/postmirror.sh
     fi
     sed -i "s%^\$config_file = .*%\$config_file = \"${script_dir}/_metadata/${repo_name}/aptmirror_url.conf\";%" ${script_dir}/_bin/${repo_name}/apt-mirror;
     sed -i "s%\"base_path\"   => .*%\"base_path\"   => '${script_dir}/_bin/${repo_name}',%" ${script_dir}/_bin/${repo_name}/apt-mirror;

--- a/bashellite.sh
+++ b/bashellite.sh
@@ -6,7 +6,7 @@
 ### Program Contributors: Eric Lake <EricLake@Gmail.com>
 #
 ### Program Version:
-    script_version="0.3.2-beta"
+    script_version="0.3.3-beta"
 #
 ### Program Purpose:
 #   The purpose of this program is to create an automated method for pulling


### PR DESCRIPTION
I updated the apt-mirror setup due to an error that is scene at the end of a apt-mirror execution.  The error message indicates that it tries to run a script called 'postmirror.sh' in the 'var' directory.  I examined the apt-mirror.sh script and verified that it looks for the file in the local 'var' directory.  However, that file doesn't exist there.  The 'postmirror.sh' script does exist at the top level dir that apt-mirror is located.  So I added a precreation of the local 'var' directory and symlinked the 'postmirror.sh' script to that locally created 'var' dir.

I next updated the version.