### PR TITLE
Updated rsync to fix problem of not downloading symlinks.

### DIFF
--- a/bashellite.sh
+++ b/bashellite.sh
@@ -416,7 +416,7 @@ Sync_repository() {
     else
       dryrun_flag="";
     fi
-    rsync -avSLP ${repo_url} \
+    rsync -avSP ${repo_url} \
       ${dryrun_flag} \
       --exclude-from="${metadata_tld}/repos.conf.d/${repo_name}/provider.conf" \
       --safe-links \


### PR DESCRIPTION
Sync_repository() was updated.  For rsync, the 'L' flag was causing
rsync to transform symlinks into their respective files/dirs.  Removing
the flag now causes rsync to download symlinks as symlinks.