### PR TITLE
Fixed error where passed in mirror tld was being ignored.

### DIFF
--- a/usr/local/lib/bashellite-libs.sh
+++ b/usr/local/lib/bashellite-libs.sh
@@ -135,7 +135,7 @@ bashelliteSetup() {
    case "${passed_parameter}" in
       m)
         # Variable initialized here, but finalized below case statement
-        _r_mirror_tld="${OPTARG}";
+        local mirror_tld="${OPTARG}";
         ;;
       r)
         # Sanitizes the directory name of spaces or any other undesired characters.


### PR DESCRIPTION
During testing of an apt-mirror change, realized a passed in value for the mirror_tld was not being set properly.  This is a proposed correction.