### PR TITLE
Recorrected an error that was reintroduced with mirror_tld option.

### DIFF
--- a/usr/local/lib/bashellite-libs.sh
+++ b/usr/local/lib/bashellite-libs.sh
@@ -135,7 +135,7 @@ bashelliteSetup() {
    case "${passed_parameter}" in
       m)
         # Variable initialized here, but finalized below case statement
-        _r_mirror_tld="${OPTARG}";
+        local mirror_tld="${OPTARG}";
         ;;
       r)
         # Sanitizes the directory name of spaces or any other undesired characters.


### PR DESCRIPTION
In the previous PR merge, the parsing of the -m parameter error that was previously "fixed" was reintroduced.  So this PR fixes the error again.